### PR TITLE
Ride multi messages

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,13 +9,15 @@ services:
       - MONGODB_URI=mongodb://mongodb:27017/bikebot
     depends_on:
       - mongodb
-    restart: always
+    restart: no
 
   mongodb:
     image: mongo:6
+    ports:
+      - "27017:27017"
     volumes:
       - mongodb_data:/data/db
-    restart: always
+    restart: no
 
 volumes:
   mongodb_data: 

--- a/src/__tests__/commands/cancel-ride-command-handler.test.js
+++ b/src/__tests__/commands/cancel-ride-command-handler.test.js
@@ -128,8 +128,9 @@ describe('CancelRideCommandHandler', () => {
       const mockRide = { 
         id: '456', 
         cancelled: true,
-        messageId: 789,
-        chatId: 101112
+        messages: [
+          { messageId: 789, chatId: 101112 }
+        ]
       };
       
       const mockParticipants = [{ id: 123, name: 'Test User' }];
@@ -167,8 +168,9 @@ describe('CancelRideCommandHandler', () => {
       const mockRide = { 
         id: '456', 
         cancelled: true,
-        messageId: 789,
-        chatId: 101112
+        messages: [
+          { messageId: 789, chatId: 101112 }
+        ]
       };
       
       const mockParticipants = [{ id: 123, name: 'Test User' }];

--- a/src/__tests__/commands/delete-ride-command-handler.test.js
+++ b/src/__tests__/commands/delete-ride-command-handler.test.js
@@ -169,7 +169,7 @@ describe('DeleteRideCommandHandler', () => {
     
     it('should handle successful deletion with message ID', async () => {
       // Setup
-      const mockRide = { id: '456', messageId: 789, chatId: 101112 };
+      const mockRide = { id: '456', messages: [{ messageId: 789, chatId: 101112 }] };
       mockRideService.getRide.mockResolvedValue(mockRide);
       mockRideService.isRideCreator.mockReturnValue(true);
       mockRideService.deleteRide.mockResolvedValue(true);
@@ -188,7 +188,7 @@ describe('DeleteRideCommandHandler', () => {
     
     it('should handle error when deleting original message', async () => {
       // Setup
-      const mockRide = { id: '456', messageId: 789, chatId: 101112 };
+      const mockRide = { id: '456', messages: [{ messageId: 789, chatId: 101112 }] };
       mockRideService.getRide.mockResolvedValue(mockRide);
       mockRideService.isRideCreator.mockReturnValue(true);
       mockRideService.deleteRide.mockResolvedValue(true);

--- a/src/__tests__/commands/duplicate-ride-command-handler.test.js
+++ b/src/__tests__/commands/duplicate-ride-command-handler.test.js
@@ -241,7 +241,7 @@ describe('DuplicateRideCommandHandler', () => {
       expect(mockRideService.parseDateTimeInput).toHaveBeenCalledWith('tomorrow 11:00');
       expect(mockRideService.createRide).toHaveBeenCalledWith(expect.objectContaining({
         title: 'New Ride',
-        chatId: 789,
+        messages: [],
         createdBy: 101112,
         meetingPoint: 'New Location',
         routeLink: 'https://example.com/route',
@@ -262,7 +262,10 @@ describe('DuplicateRideCommandHandler', () => {
       }));
       
       expect(mockRideService.updateRide).toHaveBeenCalledWith('456', {
-        messageId: 13579
+        messages: [{
+          chatId: 789,
+          messageId: 13579
+        }]
       });
       
       expect(mockCtx.reply).toHaveBeenCalledWith('Ride duplicated successfully!');
@@ -338,7 +341,7 @@ describe('DuplicateRideCommandHandler', () => {
       // Verify
       expect(mockRideService.createRide).toHaveBeenCalledWith(expect.objectContaining({
         title: 'Test Ride',
-        chatId: 789,
+        messages: [],
         createdBy: 101112,
         meetingPoint: 'Test Location',
         routeLink: 'https://example.com/route',

--- a/src/__tests__/commands/new-ride-command-handler.test.js
+++ b/src/__tests__/commands/new-ride-command-handler.test.js
@@ -168,7 +168,7 @@ describe('NewRideCommandHandler', () => {
       }));
       
       expect(mockRideService.updateRide).toHaveBeenCalledWith('123', {
-        messageId: 13579
+        messages: [{ chatId: 789, messageId: 13579 }]
       });
     });
     

--- a/src/__tests__/commands/participation-handlers.test.js
+++ b/src/__tests__/commands/participation-handlers.test.js
@@ -245,11 +245,26 @@ describe('ParticipationHandlers', () => {
   });
   
   describe('updateRideMessage', () => {
-    it('should not update if messageId or chatId is missing', async () => {
+    it('should not update if messages array is missing', async () => {
       // Setup
       const mockRide = {
         id: '123'
-        // No messageId or chatId
+        // No messages array
+      };
+      
+      // Execute
+      await participationHandlers.updateRideMessage(mockRide, mockCtx);
+      
+      // Verify
+      expect(mockRideService.getParticipants).not.toHaveBeenCalled();
+      expect(mockCtx.api.editMessageText).not.toHaveBeenCalled();
+    });
+    
+    it('should not update if messages array is empty', async () => {
+      // Setup
+      const mockRide = {
+        id: '123',
+        messages: []
       };
       
       // Execute
@@ -264,8 +279,9 @@ describe('ParticipationHandlers', () => {
       // Setup
       const mockRide = {
         id: '123',
-        messageId: 789,
-        chatId: 101112
+        messages: [
+          { messageId: 789, chatId: 101112 }
+        ]
       };
       const mockParticipants = [
         { userId: 456, firstName: 'Test', lastName: 'User' }
@@ -298,8 +314,9 @@ describe('ParticipationHandlers', () => {
       // Setup
       const mockRide = {
         id: '123',
-        messageId: 789,
-        chatId: 101112
+        messages: [
+          { messageId: 789, chatId: 101112 }
+        ]
       };
       mockRideService.getParticipants.mockRejectedValue(new Error('Database error'));
       

--- a/src/__tests__/commands/update-ride-command-handler.test.js
+++ b/src/__tests__/commands/update-ride-command-handler.test.js
@@ -244,12 +244,28 @@ describe('UpdateRideCommandHandler', () => {
   });
   
   describe('updateRideMessage', () => {
-    it('should not update if messageId or chatId is missing', async () => {
+    it('should not update if messages array is missing', async () => {
       // Setup
       const ride = {
         id: '123',
         title: 'Test Ride'
-        // No messageId or chatId
+        // No messages array
+      };
+      
+      // Execute
+      await updateRideCommandHandler.updateRideMessage(ride, mockCtx);
+      
+      // Verify
+      expect(mockRideService.getParticipants).not.toHaveBeenCalled();
+      expect(mockCtx.api.editMessageText).not.toHaveBeenCalled();
+    });
+    
+    it('should not update if messages array is empty', async () => {
+      // Setup
+      const ride = {
+        id: '123',
+        title: 'Test Ride',
+        messages: []
       };
       
       // Execute
@@ -265,8 +281,9 @@ describe('UpdateRideCommandHandler', () => {
       const ride = {
         id: '123',
         title: 'Test Ride',
-        messageId: 789,
-        chatId: 101112
+        messages: [
+          { messageId: 789, chatId: 101112 }
+        ]
       };
       
       const participants = [
@@ -303,8 +320,9 @@ describe('UpdateRideCommandHandler', () => {
       const ride = {
         id: '123',
         title: 'Test Ride',
-        messageId: 789,
-        chatId: 101112
+        messages: [
+          { messageId: 789, chatId: 101112 }
+        ]
       };
       
       mockRideService.getParticipants.mockRejectedValue(new Error('Database error'));

--- a/src/__tests__/services/ride-service.test.js
+++ b/src/__tests__/services/ride-service.test.js
@@ -21,7 +21,7 @@ describe('RideService', () => {
   const testRide = {
     title: 'Test Ride',
     date: new Date('2024-03-15T15:00:00Z'),
-    chatId: 123456,
+    messages: [{ chatId: 123456, messageId: 789123 }],
     createdBy: 789,
     meetingPoint: 'Test Location',
     routeLink: 'https://example.com/route',
@@ -54,7 +54,7 @@ describe('RideService', () => {
       expect(ride).toHaveProperty('id');
       expect(ride.title).toBe(testRide.title);
       expect(ride.date).toEqual(testRide.date);
-      expect(ride.chatId).toBe(testRide.chatId);
+      expect(ride.messages).toEqual(testRide.messages);
     });
 
     it('should get a ride by ID', async () => {
@@ -104,7 +104,7 @@ describe('RideService', () => {
         title: 'Test Ride',
         date: new Date(),
         createdBy: 123,
-        chatId: 456,
+
         messages: [{ chatId: 456, messageId: 789 }, { chatId: 789, messageId: 123 }]
       };
       
@@ -126,7 +126,7 @@ describe('RideService', () => {
         title: 'Test Ride',
         date: new Date(),
         createdBy: 123,
-        chatId: 456,
+
         messages: [{ chatId: 456, messageId: 789 }, { chatId: 789, messageId: 123 }]
       };
       

--- a/src/__tests__/storage/memory-storage.test.js
+++ b/src/__tests__/storage/memory-storage.test.js
@@ -19,6 +19,18 @@ describe('MemoryStorage', () => {
     speedMin: 25,
     speedMax: 28
   };
+  
+  const testRideWithMessages = {
+    title: 'Test Ride with Messages',
+    date: new Date('2024-03-15T15:00:00Z'),
+    messages: [{ chatId: 123456, messageId: 789012 }],
+    createdBy: 789,
+    meetingPoint: 'Test Location',
+    distance: 50,
+    duration: 180,
+    speedMin: 25,
+    speedMax: 28
+  };
 
   beforeEach(() => {
     storage = new MemoryStorage();
@@ -62,8 +74,8 @@ describe('MemoryStorage', () => {
   });
 
   describe('Data Persistence', () => {
-    it('should maintain ride data between operations', async () => {
-      // Create ride
+    it('should maintain ride data between operations with legacy format', async () => {
+      // Create ride with legacy format
       const ride = await storage.createRide(testRide);
       
       // Add participant
@@ -79,6 +91,45 @@ describe('MemoryStorage', () => {
       expect(updatedRide.title).toBe('Updated Ride');
       expect(participants).toHaveLength(1);
       expect(participants[0].username).toBe('test');
+      
+      // Verify messages array was created
+      expect(updatedRide.messages).toBeDefined();
+      expect(updatedRide.messages).toHaveLength(1);
+      expect(updatedRide.messages[0].chatId).toBe(testRide.chatId);
+      expect(updatedRide.messages[0].messageId).toBe(testRide.messageId);
+      
+      // Verify backward compatibility
+      expect(updatedRide.chatId).toBe(testRide.chatId);
+      expect(updatedRide.messageId).toBe(testRide.messageId);
+    });
+    
+    it('should maintain ride data between operations with new messages format', async () => {
+      // Create ride with new messages format
+      const ride = await storage.createRide(testRideWithMessages);
+      
+      // Add participant
+      await storage.addParticipant(ride.id, { userId: 123, username: 'test', firstName: 'Test', lastName: 'User' });
+      
+      // Update ride
+      await storage.updateRide(ride.id, { title: 'Updated Ride' });
+      
+      // Verify all data is maintained
+      const updatedRide = await storage.getRide(ride.id);
+      const participants = await storage.getParticipants(ride.id);
+      
+      expect(updatedRide.title).toBe('Updated Ride');
+      expect(participants).toHaveLength(1);
+      expect(participants[0].username).toBe('test');
+      
+      // Verify messages array is maintained
+      expect(updatedRide.messages).toBeDefined();
+      expect(updatedRide.messages).toHaveLength(1);
+      expect(updatedRide.messages[0].chatId).toBe(testRideWithMessages.messages[0].chatId);
+      expect(updatedRide.messages[0].messageId).toBe(testRideWithMessages.messages[0].messageId);
+      
+      // Verify backward compatibility fields
+      expect(updatedRide.chatId).toBe(testRideWithMessages.messages[0].chatId);
+      expect(updatedRide.messageId).toBe(testRideWithMessages.messages[0].messageId);
     });
 
     it('should maintain separate participant lists for different rides', async () => {
@@ -102,17 +153,17 @@ describe('MemoryStorage', () => {
     it('should sort rides by date in descending order', async () => {
       // Create rides with different dates
       await storage.createRide({
-        ...testRide,
+        ...testRideWithMessages,
         title: 'Ride 1',
         date: new Date('2024-03-15T15:00:00Z')
       });
       await storage.createRide({
-        ...testRide,
+        ...testRideWithMessages,
         title: 'Ride 2',
         date: new Date('2024-03-16T15:00:00Z')
       });
       await storage.createRide({
-        ...testRide,
+        ...testRideWithMessages,
         title: 'Ride 3',
         date: new Date('2024-03-17T15:00:00Z')
       });
@@ -122,6 +173,81 @@ describe('MemoryStorage', () => {
       // Verify descending order
       expect(result.rides[0].date.getTime()).toBeGreaterThan(result.rides[1].date.getTime());
       expect(result.rides[1].date.getTime()).toBeGreaterThan(result.rides[2].date.getTime());
+    });
+  });
+  
+  describe('Messages Array Handling', () => {
+    it('should update the first message when updating messageId/chatId directly', async () => {
+      // Create ride with legacy format
+      const ride = await storage.createRide(testRide);
+      
+      // Update messageId/chatId directly
+      const updatedRide = await storage.updateRide(ride.id, { 
+        messageId: 999999,
+        chatId: 888888
+      });
+      
+      // Verify messages array was updated
+      expect(updatedRide.messages).toHaveLength(1);
+      expect(updatedRide.messages[0].messageId).toBe(999999);
+      expect(updatedRide.messages[0].chatId).toBe(888888);
+      
+      // Verify backward compatibility fields
+      expect(updatedRide.messageId).toBe(999999);
+      expect(updatedRide.chatId).toBe(888888);
+    });
+    
+    it('should add a new message when updating empty messages array with messageId/chatId', async () => {
+      // Create ride with no messages
+      const noMessagesRide = {
+        title: 'Ride with no messages',
+        date: new Date('2024-03-15T15:00:00Z'),
+        createdBy: 789,
+        messages: []
+      };
+      
+      const ride = await storage.createRide(noMessagesRide);
+      
+      // Update messageId/chatId directly
+      const updatedRide = await storage.updateRide(ride.id, { 
+        messageId: 111111,
+        chatId: 222222
+      });
+      
+      // Verify a new message was added to the array
+      expect(updatedRide.messages).toHaveLength(1);
+      expect(updatedRide.messages[0].messageId).toBe(111111);
+      expect(updatedRide.messages[0].chatId).toBe(222222);
+      
+      // Verify backward compatibility fields
+      expect(updatedRide.messageId).toBe(111111);
+      expect(updatedRide.chatId).toBe(222222);
+    });
+    
+    it('should directly update the messages array when provided', async () => {
+      // Create ride with legacy format
+      const ride = await storage.createRide(testRide);
+      
+      // Update with new messages array
+      const newMessages = [
+        { messageId: 111111, chatId: 222222 },
+        { messageId: 333333, chatId: 444444 }
+      ];
+      
+      const updatedRide = await storage.updateRide(ride.id, { 
+        messages: newMessages
+      });
+      
+      // Verify messages array was updated
+      expect(updatedRide.messages).toHaveLength(2);
+      expect(updatedRide.messages[0].messageId).toBe(111111);
+      expect(updatedRide.messages[0].chatId).toBe(222222);
+      expect(updatedRide.messages[1].messageId).toBe(333333);
+      expect(updatedRide.messages[1].chatId).toBe(444444);
+      
+      // Verify backward compatibility fields use first message
+      expect(updatedRide.messageId).toBe(111111);
+      expect(updatedRide.chatId).toBe(222222);
     });
   });
 }); 

--- a/src/__tests__/storage/mongodb-storage.test.js
+++ b/src/__tests__/storage/mongodb-storage.test.js
@@ -9,8 +9,7 @@ let storage;
 const testRide = {
   title: 'Test Ride',
   date: new Date('2024-03-20T10:00:00Z'),
-  chatId: 123456,
-  messageId: 789012,
+  messages: [{ chatId: 123456, messageId: 789012 }],
   createdBy: 789,
   routeLink: 'https://example.com/route',
   meetingPoint: 'Test Location',
@@ -63,7 +62,7 @@ afterEach(async () => {
 
 describe('MongoDBStorage', () => {
   describe('Ride Management', () => {
-    test('should create a new ride with legacy format', async () => {
+    test('should create a new ride', async () => {
       const ride = await storage.createRide(testRide);
       
       // Verify the ride was created with expected properties
@@ -72,35 +71,11 @@ describe('MongoDBStorage', () => {
       expect(ride.participants).toEqual([]);
       expect(ride.id).toBeDefined();
       
-      // Verify messages array was created from legacy format
-      expect(ride.messages).toBeDefined();
-      expect(ride.messages).toHaveLength(1);
-      expect(ride.messages[0].chatId).toBe(testRide.chatId);
-      expect(ride.messages[0].messageId).toBe(testRide.messageId);
-      
-      // Verify backward compatibility
-      expect(ride.chatId).toBe(testRide.chatId);
-      expect(ride.messageId).toBe(testRide.messageId);
-    });
-    
-    test('should create a new ride with messages array', async () => {
-      const ride = await storage.createRide(testRideWithMessages);
-      
-      // Verify the ride was created with expected properties
-      expect(ride.title).toBe(testRideWithMessages.title);
-      expect(ride.date).toEqual(testRideWithMessages.date);
-      expect(ride.participants).toEqual([]);
-      expect(ride.id).toBeDefined();
-      
       // Verify messages array was maintained
       expect(ride.messages).toBeDefined();
       expect(ride.messages).toHaveLength(1);
-      expect(ride.messages[0].chatId).toBe(testRideWithMessages.messages[0].chatId);
-      expect(ride.messages[0].messageId).toBe(testRideWithMessages.messages[0].messageId);
-      
-      // Verify backward compatibility fields
-      expect(ride.chatId).toBe(testRideWithMessages.messages[0].chatId);
-      expect(ride.messageId).toBe(testRideWithMessages.messages[0].messageId);
+      expect(ride.messages[0].chatId).toBe(testRide.messages[0].chatId);
+      expect(ride.messages[0].messageId).toBe(testRide.messages[0].messageId);
     });
 
     test('should get a ride by id', async () => {
@@ -132,7 +107,7 @@ describe('MongoDBStorage', () => {
       expect(updated.messages[0].messageId).toBe(testRideWithMessages.messages[0].messageId);
     });
     
-    test('should update messageId/chatId via messages array', async () => {
+    test('should update messages array', async () => {
       const created = await storage.createRide(testRide);
       
       // Update with new messages array
@@ -149,29 +124,6 @@ describe('MongoDBStorage', () => {
       expect(updated.messages[0].chatId).toBe(222222);
       expect(updated.messages[1].messageId).toBe(333333);
       expect(updated.messages[1].chatId).toBe(444444);
-      
-      // Verify backward compatibility fields use first message
-      expect(updated.messageId).toBe(111111);
-      expect(updated.chatId).toBe(222222);
-    });
-    
-    test('should update messageId/chatId directly and convert to messages array', async () => {
-      const created = await storage.createRide(testRide);
-      
-      // Update messageId/chatId directly
-      const updated = await storage.updateRide(created.id, { 
-        messageId: 999999,
-        chatId: 888888
-      });
-      
-      // Verify messages array was updated
-      expect(updated.messages).toHaveLength(1);
-      expect(updated.messages[0].messageId).toBe(999999);
-      expect(updated.messages[0].chatId).toBe(888888);
-      
-      // Verify backward compatibility fields
-      expect(updated.messageId).toBe(999999);
-      expect(updated.chatId).toBe(888888);
     });
 
     test('should delete a ride', async () => {

--- a/src/commands/CancelRideCommandHandler.js
+++ b/src/commands/CancelRideCommandHandler.js
@@ -29,31 +29,5 @@ export class CancelRideCommandHandler extends BaseCommandHandler {
     await ctx.reply('Ride cancelled successfully.');
   }
 
-  /**
-   * Update the ride message
-   * @param {Object} ride - Ride object
-   * @param {import('grammy').Context} ctx - Grammy context
-   */
-  async updateRideMessage(ride, ctx) {
-    if (!ride.messageId || !ride.chatId) {
-      return;
-    }
 
-    try {
-      const participants = await this.rideService.getParticipants(ride.id);
-      const { message, keyboard, parseMode } = this.messageFormatter.formatRideWithKeyboard(ride, participants);
-      
-      await ctx.api.editMessageText(
-        ride.chatId,
-        ride.messageId,
-        message,
-        {
-          parse_mode: parseMode,
-          reply_markup: keyboard
-        }
-      );
-    } catch (error) {
-      console.error('Error updating ride message:', error);
-    }
-  }
 }

--- a/src/commands/DeleteRideCommandHandler.js
+++ b/src/commands/DeleteRideCommandHandler.js
@@ -61,12 +61,14 @@ export class DeleteRideCommandHandler extends BaseCommandHandler {
     if (success) {
       await ctx.editMessageText('Ride deleted successfully.');
       
-      // Try to delete the original ride message
-      if (ride.messageId) {
-        try {
-          await ctx.api.deleteMessage(ride.chatId, ride.messageId);
-        } catch (error) {
-          console.error('Error deleting ride message:', error);
+      // Try to delete all ride messages
+      if (ride.messages && ride.messages.length > 0) {
+        for (const message of ride.messages) {
+          try {
+            await ctx.api.deleteMessage(message.chatId, message.messageId);
+          } catch (error) {
+            console.error(`Error deleting ride message in chat ${message.chatId}:`, error);
+          }
         }
       }
       

--- a/src/commands/DuplicateRideCommandHandler.js
+++ b/src/commands/DuplicateRideCommandHandler.js
@@ -61,7 +61,7 @@ export class DuplicateRideCommandHandler extends BaseCommandHandler {
       // Create a new ride data object based on the original ride
       const rideData = {
         title: params.title || originalRide.title,
-        chatId: ctx.chat.id,
+        messages: [],
         createdBy: ctx.from.id,
         meetingPoint: params.meet || originalRide.meetingPoint,
         routeLink: params.route || originalRide.routeLink,
@@ -106,9 +106,12 @@ export class DuplicateRideCommandHandler extends BaseCommandHandler {
         reply_markup: keyboard
       });
 
-      // Update the ride with the message ID
+      // Update the ride with the message info in the messages array
       await this.rideService.updateRide(ride.id, {
-        messageId: sentMessage.message_id
+        messages: [{
+          chatId: ctx.chat.id,
+          messageId: sentMessage.message_id
+        }]
       });
 
       await ctx.reply('Ride duplicated successfully!');

--- a/src/commands/NewRideCommandHandler.js
+++ b/src/commands/NewRideCommandHandler.js
@@ -56,9 +56,12 @@ export class NewRideCommandHandler extends BaseCommandHandler {
       reply_markup: keyboard
     });
 
-    // Update the ride with the message ID
+    // Update the ride with the message info in the messages array
     await this.rideService.updateRide(ride.id, {
-      messageId: sentMessage.message_id
+      messages: [{
+        messageId: sentMessage.message_id,
+        chatId: ctx.chat.id
+      }]
     });
   }
 }

--- a/src/commands/ParticipationHandlers.js
+++ b/src/commands/ParticipationHandlers.js
@@ -77,31 +77,5 @@ export class ParticipationHandlers extends BaseCommandHandler {
     }
   }
 
-  /**
-   * Update the ride message
-   * @param {Object} ride - Ride object
-   * @param {import('grammy').Context} ctx - Grammy context
-   */
-  async updateRideMessage(ride, ctx) {
-    if (!ride.messageId || !ride.chatId) {
-      return;
-    }
 
-    try {
-      const participants = await this.rideService.getParticipants(ride.id);
-      const { message, keyboard, parseMode } = this.messageFormatter.formatRideWithKeyboard(ride, participants);
-      
-      await ctx.api.editMessageText(
-        ride.chatId,
-        ride.messageId,
-        message,
-        {
-          parse_mode: parseMode,
-          reply_markup: keyboard
-        }
-      );
-    } catch (error) {
-      console.error('Error updating ride message:', error);
-    }
-  }
 }

--- a/src/commands/UpdateRideCommandHandler.js
+++ b/src/commands/UpdateRideCommandHandler.js
@@ -71,31 +71,5 @@ export class UpdateRideCommandHandler extends BaseCommandHandler {
     await ctx.reply('Ride updated successfully!');
   }
 
-  /**
-   * Update the ride message
-   * @param {Object} ride - Ride object
-   * @param {import('grammy').Context} ctx - Grammy context
-   */
-  async updateRideMessage(ride, ctx) {
-    if (!ride.messageId || !ride.chatId) {
-      return;
-    }
 
-    try {
-      const participants = await this.rideService.getParticipants(ride.id);
-      const { message, keyboard, parseMode } = this.messageFormatter.formatRideWithKeyboard(ride, participants);
-      
-      await ctx.api.editMessageText(
-        ride.chatId,
-        ride.messageId,
-        message,
-        {
-          parse_mode: parseMode,
-          reply_markup: keyboard
-        }
-      );
-    } catch (error) {
-      console.error('Error updating ride message:', error);
-    }
-  }
 }

--- a/src/services/RideService.js
+++ b/src/services/RideService.js
@@ -181,7 +181,7 @@ export class RideService {
       const rideData = {
         title: params.title,
         date: result.date,
-        chatId: chatId,
+        messages: [{ chatId: chatId, messageId: null }],
         createdBy: userId
       };
 

--- a/src/services/RideService.js
+++ b/src/services/RideService.js
@@ -181,7 +181,7 @@ export class RideService {
       const rideData = {
         title: params.title,
         date: result.date,
-        messages: [{ chatId: chatId, messageId: null }],
+        messages: [], // Initialize with empty array instead of null messageId
         createdBy: userId
       };
 

--- a/src/storage/interface.js
+++ b/src/storage/interface.js
@@ -24,7 +24,7 @@
 /**
  * @typedef {Object} Participant
  * @property {number} userId
- * @property {string} username
+ * @property {string} [username]
  * @property {string} [firstName]
  * @property {string} [lastName]
  * @property {Date} joinedAt

--- a/src/storage/interface.js
+++ b/src/storage/interface.js
@@ -1,8 +1,13 @@
 /**
- * @typedef {Object} Ride
- * @property {string} id
+ * @typedef {Object} RideMessage
  * @property {number} messageId
  * @property {number} chatId
+ */
+
+/**
+ * @typedef {Object} Ride
+ * @property {string} id
+ * @property {RideMessage[]} messages
  * @property {string} title
  * @property {Date} date
  * @property {string} [routeLink]

--- a/src/storage/mongodb.js
+++ b/src/storage/mongodb.js
@@ -4,7 +4,7 @@ import { config } from '../config.js';
 
 const participantSchema = new mongoose.Schema({
   userId: { type: Number, required: true },
-  username: { type: String, required: true },
+  username: { type: String, default: '' }, // Optional as Telegram usernames are optional
   firstName: { type: String, default: '' },
   lastName: { type: String, default: '' },
   joinedAt: { type: Date, default: Date.now }

--- a/src/wizard/RideWizard.js
+++ b/src/wizard/RideWizard.js
@@ -182,7 +182,7 @@ export class RideWizard {
             const ride = await this.storage.createRide({
               title: state.data.title,
               date: state.data.datetime,
-              messages: [{ chatId: state.data.chatId, messageId: null }],
+              messages: [], // Initialize with empty array instead of null messageId
               createdBy: state.data.createdBy,
               meetingPoint: state.data.meetingPoint,
               routeLink: state.data.routeLink,


### PR DESCRIPTION
This is a preparation step for changing how the rides are announced. In this step, we change the data model from a single chatId/messageId to an array of messages. We don't yet support multiple messages per ride in the app business logic.