### PR TITLE
Postride command

### DIFF
--- a/src/__tests__/commands/cancel-ride-command-handler.test.js
+++ b/src/__tests__/commands/cancel-ride-command-handler.test.js
@@ -18,7 +18,8 @@ describe('CancelRideCommandHandler', () => {
       getRide: jest.fn(),
       isRideCreator: jest.fn(),
       cancelRide: jest.fn(),
-      getParticipants: jest.fn()
+      getParticipants: jest.fn(),
+      updateRideMessages: jest.fn().mockResolvedValue({ success: true, updatedCount: 1, removedCount: 0 })
     };
     
     // Create mock MessageFormatter
@@ -147,17 +148,7 @@ describe('CancelRideCommandHandler', () => {
       await cancelRideCommandHandler.updateRideMessage(mockRide, mockCtx);
       
       // Verify
-      expect(mockRideService.getParticipants).toHaveBeenCalledWith('456');
-      expect(mockMessageFormatter.formatRideWithKeyboard).toHaveBeenCalledWith(mockRide, mockParticipants);
-      expect(mockCtx.api.editMessageText).toHaveBeenCalledWith(
-        101112,
-        789,
-        'Formatted ride message',
-        {
-          parse_mode: 'HTML',
-          reply_markup: { inline_keyboard: [] }
-        }
-      );
+      expect(mockRideService.updateRideMessages).toHaveBeenCalledWith(mockRide, mockCtx);
     });
     
     it('should handle errors when updating message', async () => {
@@ -180,9 +171,7 @@ describe('CancelRideCommandHandler', () => {
         parseMode: 'HTML'
       };
       
-      mockRideService.getParticipants.mockResolvedValue(mockParticipants);
-      mockMessageFormatter.formatRideWithKeyboard.mockReturnValue(mockFormatResult);
-      mockCtx.api.editMessageText.mockRejectedValue(new Error('API error'));
+      mockRideService.updateRideMessages.mockResolvedValue({ success: false, error: 'API error' });
       
       // Mock console.error to prevent test output pollution
       const originalConsoleError = console.error;
@@ -193,9 +182,7 @@ describe('CancelRideCommandHandler', () => {
         await cancelRideCommandHandler.updateRideMessage(mockRide, mockCtx);
         
         // Verify
-        expect(mockRideService.getParticipants).toHaveBeenCalledWith('456');
-        expect(mockMessageFormatter.formatRideWithKeyboard).toHaveBeenCalledWith(mockRide, mockParticipants);
-        expect(mockCtx.api.editMessageText).toHaveBeenCalled();
+        expect(mockRideService.updateRideMessages).toHaveBeenCalledWith(mockRide, mockCtx);
         expect(console.error).toHaveBeenCalled();
       } finally {
         // Restore console.error

--- a/src/__tests__/commands/post-ride-command-handler.test.js
+++ b/src/__tests__/commands/post-ride-command-handler.test.js
@@ -178,7 +178,8 @@ describe('PostRideCommandHandler', () => {
         101112,
         mockCtx
       );
-      expect(mockCtx.reply).toHaveBeenCalledWith('Ride #123 successfully posted to this chat.');
+      // No confirmation message is expected now
+      expect(mockCtx.reply).not.toHaveBeenCalledWith('Ride #123 successfully posted to this chat.');
     });
     
     it('should handle error when posting ride', async () => {

--- a/src/__tests__/commands/post-ride-command-handler.test.js
+++ b/src/__tests__/commands/post-ride-command-handler.test.js
@@ -1,0 +1,342 @@
+/**
+ * @jest-environment node
+ */
+
+import { jest } from '@jest/globals';
+import { PostRideCommandHandler } from '../../commands/PostRideCommandHandler.js';
+
+// Mock the grammy module
+jest.mock('grammy', () => {
+  return {
+    InlineKeyboard: jest.fn().mockImplementation(() => {
+      return {
+        text: jest.fn().mockReturnThis(),
+        row: jest.fn().mockReturnThis()
+      };
+    })
+  };
+});
+
+describe('PostRideCommandHandler', () => {
+  let postRideCommandHandler;
+  let mockRideService;
+  let mockMessageFormatter;
+  let mockCtx;
+  
+  beforeEach(() => {
+    // Create mock RideService
+    mockRideService = {
+      getRide: jest.fn(),
+      isRideCreator: jest.fn(),
+      getParticipants: jest.fn(),
+      updateRide: jest.fn()
+    };
+    
+    // Create mock MessageFormatter
+    mockMessageFormatter = {
+      formatRideWithKeyboard: jest.fn()
+    };
+    
+    // Create mock Grammy context
+    mockCtx = {
+      message: {
+        text: '/postride 123',
+        message_id: 456
+      },
+      from: {
+        id: 789,
+        first_name: 'Test',
+        username: 'testuser'
+      },
+      chat: {
+        id: 101112
+      },
+      reply: jest.fn().mockResolvedValue({
+        message_id: 131415
+      })
+    };
+    
+    // Create the handler
+    postRideCommandHandler = new PostRideCommandHandler(mockRideService, mockMessageFormatter);
+    
+    // Mock the extractRideId method
+    jest.spyOn(postRideCommandHandler, 'extractRideId');
+    
+    // Mock the postRideToChat method
+    jest.spyOn(postRideCommandHandler, 'postRideToChat');
+  });
+  
+  describe('extractRideId', () => {
+    it('should extract ride ID from command text', () => {
+      // Execute
+      const result = postRideCommandHandler.extractRideId('/postride abc123');
+      
+      // Verify
+      expect(result).toBe('abc123');
+    });
+    
+    it('should return null if command text is invalid', () => {
+      // Execute
+      const result1 = postRideCommandHandler.extractRideId('/postride');
+      const result2 = postRideCommandHandler.extractRideId('/postride abc123 extra');
+      
+      // Verify
+      expect(result1).toBeNull();
+      expect(result2).toBeNull();
+    });
+  });
+  
+  describe('handle', () => {
+    it('should handle missing ride ID', async () => {
+      // Setup
+      postRideCommandHandler.extractRideId.mockReturnValue(null);
+      
+      // Execute
+      await postRideCommandHandler.handle(mockCtx);
+      
+      // Verify
+      expect(postRideCommandHandler.extractRideId).toHaveBeenCalledWith(mockCtx.message.text);
+      expect(mockCtx.reply).toHaveBeenCalledWith('Please provide a valid ride ID. Usage: /postride [ride_id]');
+      expect(mockRideService.getRide).not.toHaveBeenCalled();
+    });
+    
+    it('should handle ride not found', async () => {
+      // Setup
+      postRideCommandHandler.extractRideId.mockReturnValue('123');
+      mockRideService.getRide.mockResolvedValue(null);
+      
+      // Execute
+      await postRideCommandHandler.handle(mockCtx);
+      
+      // Verify
+      expect(postRideCommandHandler.extractRideId).toHaveBeenCalledWith(mockCtx.message.text);
+      expect(mockRideService.getRide).toHaveBeenCalledWith('123');
+      expect(mockCtx.reply).toHaveBeenCalledWith('Ride #123 not found.');
+    });
+    
+    it('should handle unauthorized user', async () => {
+      // Setup
+      postRideCommandHandler.extractRideId.mockReturnValue('123');
+      mockRideService.getRide.mockResolvedValue({ id: '123' });
+      mockRideService.isRideCreator.mockReturnValue(false);
+      
+      // Execute
+      await postRideCommandHandler.handle(mockCtx);
+      
+      // Verify
+      expect(mockRideService.isRideCreator).toHaveBeenCalledWith({ id: '123' }, 789);
+      expect(mockCtx.reply).toHaveBeenCalledWith('Only the ride creator can repost this ride.');
+    });
+    
+    it('should handle cancelled ride', async () => {
+      // Setup
+      postRideCommandHandler.extractRideId.mockReturnValue('123');
+      mockRideService.getRide.mockResolvedValue({ id: '123', cancelled: true });
+      mockRideService.isRideCreator.mockReturnValue(true);
+      
+      // Execute
+      await postRideCommandHandler.handle(mockCtx);
+      
+      // Verify
+      expect(mockCtx.reply).toHaveBeenCalledWith('Cannot repost a cancelled ride.');
+    });
+    
+    it('should handle ride already posted in chat', async () => {
+      // Setup
+      postRideCommandHandler.extractRideId.mockReturnValue('123');
+      mockRideService.getRide.mockResolvedValue({ 
+        id: '123', 
+        cancelled: false,
+        messages: [{ chatId: 101112, messageId: 999 }]
+      });
+      mockRideService.isRideCreator.mockReturnValue(true);
+      
+      // Execute
+      await postRideCommandHandler.handle(mockCtx);
+      
+      // Verify
+      expect(mockCtx.reply).toHaveBeenCalledWith('This ride is already posted in this chat.');
+    });
+    
+    it('should successfully post ride to chat', async () => {
+      // Setup
+      postRideCommandHandler.extractRideId.mockReturnValue('123');
+      mockRideService.getRide.mockResolvedValue({ 
+        id: '123', 
+        cancelled: false,
+        messages: [{ chatId: 222222, messageId: 999 }]
+      });
+      mockRideService.isRideCreator.mockReturnValue(true);
+      postRideCommandHandler.postRideToChat.mockResolvedValue({ success: true, error: null });
+      
+      // Execute
+      await postRideCommandHandler.handle(mockCtx);
+      
+      // Verify
+      expect(postRideCommandHandler.postRideToChat).toHaveBeenCalledWith(
+        { id: '123', cancelled: false, messages: [{ chatId: 222222, messageId: 999 }] },
+        101112,
+        mockCtx
+      );
+      expect(mockCtx.reply).toHaveBeenCalledWith('Ride #123 successfully posted to this chat.');
+    });
+    
+    it('should handle error when posting ride', async () => {
+      // Setup
+      postRideCommandHandler.extractRideId.mockReturnValue('123');
+      mockRideService.getRide.mockResolvedValue({ 
+        id: '123', 
+        cancelled: false,
+        messages: []
+      });
+      mockRideService.isRideCreator.mockReturnValue(true);
+      postRideCommandHandler.postRideToChat.mockResolvedValue({ 
+        success: false, 
+        error: 'The bot is not a member of this chat or was blocked.' 
+      });
+      
+      // Execute
+      await postRideCommandHandler.handle(mockCtx);
+      
+      // Verify
+      expect(mockCtx.reply).toHaveBeenCalledWith('Failed to post ride: The bot is not a member of this chat or was blocked.');
+    });
+    
+    it('should handle unexpected error', async () => {
+      // Setup
+      postRideCommandHandler.extractRideId.mockReturnValue('123');
+      mockRideService.getRide.mockRejectedValue(new Error('Database error'));
+      
+      // Execute
+      await postRideCommandHandler.handle(mockCtx);
+      
+      // Verify
+      expect(mockCtx.reply).toHaveBeenCalledWith('An error occurred while posting the ride.');
+    });
+  });
+  
+  describe('postRideToChat', () => {
+    it('should successfully post ride to chat', async () => {
+      // Setup
+      const ride = { 
+        id: '123',
+        title: 'Test Ride',
+        messages: [{ chatId: 222222, messageId: 999 }]
+      };
+      
+      const participants = [
+        { userId: 111, firstName: 'User1' },
+        { userId: 222, firstName: 'User2' }
+      ];
+      
+      mockRideService.getParticipants.mockResolvedValue(participants);
+      mockMessageFormatter.formatRideWithKeyboard.mockReturnValue({
+        message: 'Formatted ride message',
+        keyboard: { inline_keyboard: [] },
+        parseMode: 'HTML'
+      });
+      
+      mockRideService.updateRide.mockResolvedValue({
+        ...ride,
+        messages: [
+          ...ride.messages,
+          { chatId: 101112, messageId: 131415 }
+        ]
+      });
+      
+      // Execute
+      const result = await postRideCommandHandler.postRideToChat(ride, 101112, mockCtx);
+      
+      // Verify
+      expect(mockRideService.getParticipants).toHaveBeenCalledWith('123');
+      expect(mockMessageFormatter.formatRideWithKeyboard).toHaveBeenCalledWith(ride, participants);
+      expect(mockCtx.reply).toHaveBeenCalledWith('Formatted ride message', {
+        parse_mode: 'HTML',
+        reply_markup: { inline_keyboard: [] }
+      });
+      expect(mockRideService.updateRide).toHaveBeenCalledWith('123', {
+        messages: [
+          { chatId: 222222, messageId: 999 },
+          { chatId: 101112, messageId: 131415 }
+        ]
+      });
+      expect(result).toEqual({ success: true, error: null });
+    });
+    
+    it('should handle bot blocked error', async () => {
+      // Setup
+      const ride = { id: '123', messages: [] };
+      const participants = [];
+      
+      mockRideService.getParticipants.mockResolvedValue(participants);
+      mockMessageFormatter.formatRideWithKeyboard.mockReturnValue({
+        message: 'Formatted ride message',
+        keyboard: { inline_keyboard: [] },
+        parseMode: 'HTML'
+      });
+      
+      const botBlockedError = new Error('Bot error');
+      botBlockedError.description = 'Forbidden: bot was blocked by the user';
+      mockCtx.reply.mockRejectedValue(botBlockedError);
+      
+      // Execute
+      const result = await postRideCommandHandler.postRideToChat(ride, 101112, mockCtx);
+      
+      // Verify
+      expect(result).toEqual({ 
+        success: false, 
+        error: 'The bot is not a member of this chat or was blocked.' 
+      });
+    });
+    
+    it('should handle permissions error', async () => {
+      // Setup
+      const ride = { id: '123', messages: [] };
+      const participants = [];
+      
+      mockRideService.getParticipants.mockResolvedValue(participants);
+      mockMessageFormatter.formatRideWithKeyboard.mockReturnValue({
+        message: 'Formatted ride message',
+        keyboard: { inline_keyboard: [] },
+        parseMode: 'HTML'
+      });
+      
+      const permissionsError = new Error('Bot error');
+      permissionsError.description = 'Bad Request: not enough rights to send text messages to the chat';
+      mockCtx.reply.mockRejectedValue(permissionsError);
+      
+      // Execute
+      const result = await postRideCommandHandler.postRideToChat(ride, 101112, mockCtx);
+      
+      // Verify
+      expect(result).toEqual({ 
+        success: false, 
+        error: 'The bot does not have permission to send messages in this chat.' 
+      });
+    });
+    
+    it('should handle unexpected error', async () => {
+      // Setup
+      const ride = { id: '123', messages: [] };
+      const participants = [];
+      
+      mockRideService.getParticipants.mockResolvedValue(participants);
+      mockMessageFormatter.formatRideWithKeyboard.mockReturnValue({
+        message: 'Formatted ride message',
+        keyboard: { inline_keyboard: [] },
+        parseMode: 'HTML'
+      });
+      
+      mockCtx.reply.mockRejectedValue(new Error('Unexpected error'));
+      
+      // Execute
+      const result = await postRideCommandHandler.postRideToChat(ride, 101112, mockCtx);
+      
+      // Verify
+      expect(result).toEqual({ 
+        success: false, 
+        error: 'An unexpected error occurred.' 
+      });
+    });
+  });
+});

--- a/src/__tests__/commands/update-ride-command-handler.test.js
+++ b/src/__tests__/commands/update-ride-command-handler.test.js
@@ -32,7 +32,8 @@ describe('UpdateRideCommandHandler', () => {
       isRideCreator: jest.fn(),
       parseRideParams: jest.fn(),
       updateRideFromParams: jest.fn(),
-      getParticipants: jest.fn()
+      getParticipants: jest.fn(),
+      updateRideMessages: jest.fn().mockResolvedValue({ success: true, updatedCount: 1, removedCount: 0 })
     };
     
     // Create mock MessageFormatter
@@ -302,17 +303,7 @@ describe('UpdateRideCommandHandler', () => {
       await updateRideCommandHandler.updateRideMessage(ride, mockCtx);
       
       // Verify
-      expect(mockRideService.getParticipants).toHaveBeenCalledWith('123');
-      expect(mockMessageFormatter.formatRideWithKeyboard).toHaveBeenCalledWith(ride, participants);
-      expect(mockCtx.api.editMessageText).toHaveBeenCalledWith(
-        101112,
-        789,
-        'Updated ride message',
-        {
-          parse_mode: 'HTML',
-          reply_markup: { inline_keyboard: [] }
-        }
-      );
+      expect(mockRideService.updateRideMessages).toHaveBeenCalledWith(ride, mockCtx);
     });
     
     it('should handle error during message update', async () => {
@@ -325,7 +316,7 @@ describe('UpdateRideCommandHandler', () => {
         ]
       };
       
-      mockRideService.getParticipants.mockRejectedValue(new Error('Database error'));
+      mockRideService.updateRideMessages.mockResolvedValue({ success: false, error: 'Database error' });
       
       // Temporarily mock console.error
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -334,8 +325,8 @@ describe('UpdateRideCommandHandler', () => {
       await updateRideCommandHandler.updateRideMessage(ride, mockCtx);
       
       // Verify
+      expect(mockRideService.updateRideMessages).toHaveBeenCalledWith(ride, mockCtx);
       expect(consoleErrorSpy).toHaveBeenCalled();
-      expect(mockCtx.api.editMessageText).not.toHaveBeenCalled();
       
       // Restore console.error
       consoleErrorSpy.mockRestore();

--- a/src/commands/BaseCommandHandler.js
+++ b/src/commands/BaseCommandHandler.js
@@ -55,34 +55,13 @@ export class BaseCommandHandler {
    * @param {import('grammy').Context} ctx - Grammy context
    */
   async updateRideMessage(ride, ctx) {
-    // If no messages to update, return early
-    if (!ride.messages || ride.messages.length === 0) {
-      return;
-    }
-
-    try {
-      const participants = await this.rideService.getParticipants(ride.id);
-      const { message, keyboard, parseMode } = this.messageFormatter.formatRideWithKeyboard(ride, participants);
-      
-      // Update all messages for this ride
-      for (const messageInfo of ride.messages) {
-        try {
-          await ctx.api.editMessageText(
-            messageInfo.chatId,
-            messageInfo.messageId,
-            message,
-            {
-              parse_mode: parseMode,
-              reply_markup: keyboard
-            }
-          );
-        } catch (messageError) {
-          console.error(`Error updating message in chat ${messageInfo.chatId}:`, messageError);
-          // Continue with other messages even if one fails
-        }
-      }
-    } catch (error) {
-      console.error('Error updating ride messages:', error);
+    // Use the centralized method in RideService
+    const result = await this.rideService.updateRideMessages(ride, ctx);
+    
+    if (!result.success) {
+      console.error('Error updating ride messages:', result.error);
+    } else if (result.removedCount > 0) {
+      console.info(`Removed ${result.removedCount} unavailable messages from tracking for ride ${ride.id}`);
     }
   }
 }

--- a/src/commands/PostRideCommandHandler.js
+++ b/src/commands/PostRideCommandHandler.js
@@ -1,0 +1,124 @@
+import { BaseCommandHandler } from './BaseCommandHandler.js';
+
+/**
+ * Handler for the postride command
+ * Allows reposting a ride to the current chat
+ */
+export class PostRideCommandHandler extends BaseCommandHandler {
+  /**
+   * Handle the postride command
+   * @param {import('grammy').Context} ctx - Grammy context
+   */
+  async handle(ctx) {
+    // Extract the ride ID from the command
+    const rideId = this.extractRideId(ctx.message.text);
+    if (!rideId) {
+      await ctx.reply('Please provide a valid ride ID. Usage: /postride [ride_id]');
+      return;
+    }
+
+    try {
+      // Get the ride by ID
+      const ride = await this.rideService.getRide(rideId);
+      if (!ride) {
+        await ctx.reply(`Ride #${rideId} not found.`);
+        return;
+      }
+
+      // Only allow the ride creator to repost
+      if (!this.rideService.isRideCreator(ride, ctx.from.id)) {
+        await ctx.reply('Only the ride creator can repost this ride.');
+        return;
+      }
+
+      if (ride.cancelled) {
+        await ctx.reply('Cannot repost a cancelled ride.');
+        return;
+      }
+
+      const currentChatId = ctx.chat.id;
+
+      // Check if the ride is already posted in the current chat
+      if (ride.messages && ride.messages.some(msg => msg.chatId === currentChatId)) {
+        await ctx.reply(`This ride is already posted in this chat.`);
+        return;
+      }
+
+      // Post the ride to the current chat
+      const result = await this.postRideToChat(ride, currentChatId, ctx);
+      
+      if (result.success) {
+        await ctx.reply(`Ride #${rideId} successfully posted to this chat.`);
+      } else {
+        await ctx.reply(`Failed to post ride: ${result.error}`);
+      }
+    } catch (error) {
+      console.error('Error posting ride:', error);
+      await ctx.reply('An error occurred while posting the ride.');
+    }
+  }
+
+  /**
+   * Extract ride ID from command text
+   * @param {string} text - Command text
+   * @returns {string|null} - Extracted ride ID or null if invalid
+   */
+  extractRideId(text) {
+    // Format: /postride [ride_id]
+    const parts = text.trim().split(/\s+/);
+    if (parts.length !== 2) {
+      return null;
+    }
+
+    return parts[1];
+  }
+
+  /**
+   * Post a ride to the current chat
+   * @param {Object} ride - Ride object
+   * @param {number} chatId - Current chat ID
+   * @param {import('grammy').Context} ctx - Grammy context
+   * @returns {Promise<{success: boolean, error: string|null}>} - Result
+   */
+  async postRideToChat(ride, chatId, ctx) {
+    try {
+      // Get participants to display in the message
+      const participants = await this.rideService.getParticipants(ride.id);
+      
+      // Format the ride message
+      const { message, keyboard, parseMode } = this.messageFormatter.formatRideWithKeyboard(ride, participants);
+      
+      // Send the message to the current chat
+      const sentMessage = await ctx.reply(message, {
+        parse_mode: parseMode,
+        reply_markup: keyboard
+      });
+      
+      // Add the new message to the ride's messages array
+      const updatedRide = await this.rideService.updateRide(ride.id, {
+        messages: [
+          ...(ride.messages || []),
+          {
+            chatId: chatId,
+            messageId: sentMessage.message_id
+          }
+        ]
+      });
+      
+      return { success: true, error: null };
+    } catch (error) {
+      console.error('Error posting ride to chat:', error);
+      
+      // Handle common errors
+      if (error.description) {
+        if (error.description.includes('bot was blocked')) {
+          return { success: false, error: 'The bot is not a member of this chat or was blocked.' };
+        } else if (error.description.includes('not enough rights')) {
+          return { success: false, error: 'The bot does not have permission to send messages in this chat.' };
+        }
+      }
+      
+      return { success: false, error: 'An unexpected error occurred.' };
+    }
+  }
+}

--- a/src/commands/PostRideCommandHandler.js
+++ b/src/commands/PostRideCommandHandler.js
@@ -47,9 +47,7 @@ export class PostRideCommandHandler extends BaseCommandHandler {
       // Post the ride to the current chat
       const result = await this.postRideToChat(ride, currentChatId, ctx);
       
-      if (result.success) {
-        await ctx.reply(`Ride #${rideId} successfully posted to this chat.`);
-      } else {
+      if (!result.success) {
         await ctx.reply(`Failed to post ride: ${result.error}`);
       }
     } catch (error) {

--- a/src/config.js
+++ b/src/config.js
@@ -85,9 +85,10 @@ speed: 25-28
 <b>Managing Rides</b>
 
 <b>🔄 Updating a Ride</b>
-Only the ride creator can update. Two ways:
-1. Reply to the ride message with <code>/updateride</code> and new parameters
-2. Use <code>/updateride</code> with ride ID:
+Only the ride creator can update. Three ways:
+1. Reply to the ride message with <code>/updateride</code> without any parameters to start an interactive wizard.${process.env.WIZARD_ONLY_IN_PRIVATE === 'true' ? ' <i>(Note: Wizard mode is only available in private chats with the bot)</i>' : ''}
+2. Reply to the ride message with <code>/updateride</code> and new parameters
+3. Use <code>/updateride</code> with ride ID:
 <pre>
 /updateride
 id: abc123
@@ -113,11 +114,10 @@ Only the ride creator can delete:
 <pre>/deleteride id: abc123</pre>
 
 <b>🔄 Duplicating a Ride</b>
-Only the ride creator can duplicate. Two ways:
-1. Use the wizard (recommended):
-Send <code>/dupride</code> to start an interactive wizard.
-
-2. Use <code>/dupride</code> with ID and optional parameters:
+Only the ride creator can duplicate. Three ways:
+1. Reply to the ride message with <code>/dupride</code> without any parameters to start an interactive wizard.${process.env.WIZARD_ONLY_IN_PRIVATE === 'true' ? ' <i>(Note: Wizard mode is only available in private chats with the bot)</i>' : ''}
+2. Reply to the ride message with <code>/updateride</code> and new parameters
+3. Use <code>/dupride</code> with ride ID and optional parameters:
 <pre>
 /dupride
 id: abc123

--- a/src/config.js
+++ b/src/config.js
@@ -135,6 +135,13 @@ By default, the new ride will be scheduled for tomorrow at the same time.
 Use <code>/listrides</code> to see all rides you've created:
 • Rides are sorted by date (newest first)
 • Use navigation buttons to browse pages
+
+<b>📢 Reposting a Ride</b>
+Only the ride creator can repost a ride to another chat:
+1. Go to the target chat where you want to post the ride
+2. Use <code>/postride</code> with the ride ID:
+<pre>/postride abc123</pre>
+The ride will be posted to the current chat and all instances will be synchronized when details change or participants join/leave.
     `.trim(),
     ride: `
 🚲 <b>{title}</b>{cancelledBadge}

--- a/src/config.js
+++ b/src/config.js
@@ -8,7 +8,8 @@ export const config = {
     token: process.env.BOT_TOKEN,
     webhookDomain: process.env.WEBHOOK_DOMAIN,
     webhookPath: '/webhook',
-    useWebhook: process.env.NODE_ENV === 'production'
+    useWebhook: process.env.NODE_ENV === 'production',
+    wizardOnlyInPrivateChats: process.env.WIZARD_ONLY_IN_PRIVATE === 'true' || false
   },
   mongodb: {
     uri: process.env.MONGODB_URI || 'mongodb://localhost:27017/bikebot'
@@ -54,7 +55,7 @@ export const config = {
 <b>➕ Creating a New Ride</b>
 Create a new ride:
 1. Using the wizard (recommended):
-Simply send <code>/newride</code> command without any parameters to start an interactive wizard that will guide you through each step.
+Simply send <code>/newride</code> command without any parameters to start an interactive wizard that will guide you through each step.${process.env.WIZARD_ONLY_IN_PRIVATE === 'true' ? ' <i>(Note: Wizard mode is only available in private chats with the bot)</i>' : ''}
 
 2. Using command with parameters:
 Use <code>/newride</code> command followed by parameters (one per line):
@@ -114,7 +115,7 @@ Only the ride creator can delete:
 <b>🔄 Duplicating a Ride</b>
 Only the ride creator can duplicate. Two ways:
 1. Use the wizard (recommended):
-Send <code>/dupridex</code> to start an interactive wizard.
+Send <code>/dupride</code> to start an interactive wizard.
 
 2. Use <code>/dupride</code> with ID and optional parameters:
 <pre>

--- a/src/core/Bot.js
+++ b/src/core/Bot.js
@@ -10,6 +10,7 @@ import { CancelRideCommandHandler } from '../commands/CancelRideCommandHandler.j
 import { DeleteRideCommandHandler } from '../commands/DeleteRideCommandHandler.js';
 import { ListRidesCommandHandler } from '../commands/ListRidesCommandHandler.js';
 import { DuplicateRideCommandHandler } from '../commands/DuplicateRideCommandHandler.js';
+import { PostRideCommandHandler } from '../commands/PostRideCommandHandler.js';
 import { ParticipationHandlers } from '../commands/ParticipationHandlers.js';
 
 /**
@@ -37,6 +38,7 @@ export class Bot {
     this.deleteRideHandler = new DeleteRideCommandHandler(this.rideService, this.messageFormatter);
     this.listRidesHandler = new ListRidesCommandHandler(this.rideService, this.messageFormatter);
     this.duplicateRideHandler = new DuplicateRideCommandHandler(this.rideService, this.messageFormatter, this.wizard);
+    this.postRideHandler = new PostRideCommandHandler(this.rideService, this.messageFormatter);
     this.participationHandlers = new ParticipationHandlers(this.rideService, this.messageFormatter);
     
     this.setupHandlers();
@@ -54,6 +56,7 @@ export class Bot {
     this.bot.command('deleteride', ctx => this.deleteRideHandler.handle(ctx));
     this.bot.command('listrides', ctx => this.listRidesHandler.handle(ctx));
     this.bot.command('dupride', ctx => this.duplicateRideHandler.handle(ctx));
+    this.bot.command('postride', ctx => this.postRideHandler.handle(ctx));
     
     // Callback query handlers
     this.bot.callbackQuery(/^join:(.+)$/, ctx => this.participationHandlers.handleJoinRide(ctx));

--- a/src/formatters/MessageFormatter.js
+++ b/src/formatters/MessageFormatter.js
@@ -156,6 +156,14 @@ export class MessageFormatter {
         message += `📍 ${escapeHtml(ride.meetingPoint)}\n`;
       }
       
+      // Add chat information
+      if (ride.messages && ride.messages.length > 0) {
+        const chatCount = ride.messages.length;
+        message += `📢 Posted in ${chatCount} ${chatCount === 1 ? 'chat' : 'chats'}\n`;
+      } else {
+        message += `📢 Not posted in any chats\n`;
+      }
+      
       message += `🎫 Ride #${ride.id}\n\n`;
     }
     

--- a/src/wizard/RideWizard.js
+++ b/src/wizard/RideWizard.js
@@ -551,35 +551,13 @@ export class RideWizard {
   }
 
   async updateRideMessage(ride, ctx) {
-    // If no messages to update, return early
-    if (!ride.messages || ride.messages.length === 0) {
-      console.error('No messages to update for ride:', ride.id);
-      return;
-    }
-
-    try {
-      const participants = await this.storage.getParticipants(ride.id);
-      const { message, keyboard, parseMode } = this.messageFormatter.formatRideWithKeyboard(ride, participants);
-      
-      // Update all messages for this ride
-      for (const messageInfo of ride.messages) {
-        try {
-          await ctx.api.editMessageText(
-            messageInfo.chatId,
-            messageInfo.messageId,
-            message,
-            {
-              parse_mode: parseMode,
-              reply_markup: keyboard
-            }
-          );
-        } catch (messageError) {
-          console.error(`Error updating message in chat ${messageInfo.chatId}:`, messageError);
-          // Continue with other messages even if one fails
-        }
-      }
-    } catch (error) {
-      console.error('Error updating ride messages:', error);
+    // Use the centralized method in RideService
+    const result = await this.rideService.updateRideMessages(ride, ctx);
+    
+    if (!result.success) {
+      console.error('Error updating ride messages:', result.error);
+    } else if (result.removedCount > 0) {
+      console.info(`Removed ${result.removedCount} unavailable messages from tracking for ride ${ride.id}`);
     }
   }
 } 

--- a/src/wizard/RideWizard.js
+++ b/src/wizard/RideWizard.js
@@ -15,6 +15,8 @@ export class RideWizard {
     this.wizardStates = new Map();
   }
   
+
+  
   /**
    * Check if the bot has admin permissions and notify the user if not
    * @param {import('grammy').Context} ctx - Grammy context
@@ -58,6 +60,12 @@ export class RideWizard {
       return;
     }
 
+    // Check if wizards are only allowed in private chats
+    if (config.bot.wizardOnlyInPrivateChats && ctx.chat.type !== 'private') {
+      await ctx.reply('⚠️ Wizard commands are only available in private chats with the bot. Please use the command with parameters instead.');
+      return;
+    }
+
     // Check if the bot has admin permissions in the chat
     if (!await this.checkAdminPermissions(ctx)) {
       return;
@@ -92,6 +100,13 @@ export class RideWizard {
 
     if (!state) {
       await ctx.answerCallbackQuery('Wizard session expired');
+      return;
+    }
+    
+    // Check if wizards are only allowed in private chats
+    if (config.bot.wizardOnlyInPrivateChats && ctx.chat.type !== 'private') {
+      await ctx.answerCallbackQuery('⚠️ Wizard commands are only available in private chats with the bot');
+      this.wizardStates.delete(stateKey);
       return;
     }
     
@@ -228,6 +243,13 @@ export class RideWizard {
     const stateKey = this.getWizardStateKey(ctx.from.id, ctx.chat.id);
     const state = this.wizardStates.get(stateKey);
     if (!state) return;
+    
+    // Check if wizards are only allowed in private chats
+    if (config.bot.wizardOnlyInPrivateChats && ctx.chat.type !== 'private') {
+      await ctx.reply('⚠️ Wizard commands are only available in private chats with the bot. Please use the command with parameters instead.');
+      this.wizardStates.delete(stateKey);
+      return;
+    }
     
     // Check if the bot has admin permissions in the chat
     if (!await this.checkAdminPermissions(ctx, true)) {


### PR DESCRIPTION
This is the second step for changing how the rides are announced. In this step, we introduce the `/postride` command and provide an option to forbid wizard in public chats.